### PR TITLE
Add a fancy r2 using Math on PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Use shortcodes to get format specific fancy text for certain keywords or format 
 {{< ldots >}}
 {{< vdots >}}
 {{< ddots >}}
+{{< r2 >}}
 ```
 
 For example:

--- a/_extensions/fancy-text/fancy-text.lua
+++ b/_extensions/fancy-text/fancy-text.lua
@@ -60,7 +60,7 @@ function ddots()
   end
 end
  
-function r2() 
+function R2() 
   if quarto.doc.isFormat("pdf") then
     return pandoc.Math('InlineMath', "R^2")
   else

--- a/_extensions/fancy-text/fancy-text.lua
+++ b/_extensions/fancy-text/fancy-text.lua
@@ -59,3 +59,11 @@ function ddots()
     return "..."
   end
 end
+ 
+function r2() 
+  if quarto.doc.isFormat("pdf") then
+    return pandoc.Math('InlineMath', "R^2")
+  else
+    return {pandoc.Str("R"), pandoc.Superscript("2")} 
+  end
+end

--- a/example.qmd
+++ b/example.qmd
@@ -4,6 +4,7 @@ format:
   html: default
   pdf: default
   docx: default
+keep-tex: true
 ---
 
 LaTeX can be written like {{< latex >}}.
@@ -13,4 +14,6 @@ BibTeX can be written like {{< bibtex >}}.
 TeX can be written like {{< tex >}}.
 
 Various elipses are supported: {{< ldots >}}, {{< vdots >}}, {{< ddots >}}
+
+Formatting R^2^ using Math for PDF: {{< r2 >}}
 

--- a/example.qmd
+++ b/example.qmd
@@ -4,7 +4,6 @@ format:
   html: default
   pdf: default
   docx: default
-keep-tex: true
 ---
 
 LaTeX can be written like {{< latex >}}.

--- a/example.qmd
+++ b/example.qmd
@@ -14,5 +14,5 @@ TeX can be written like {{< tex >}}.
 
 Various elipses are supported: {{< ldots >}}, {{< vdots >}}, {{< ddots >}}
 
-Formatting R^2^ using Math for PDF: {{< r2 >}}
+Formatting R^2^ using Math for PDF: {{< R2 >}}
 


### PR DESCRIPTION
This adds a fancy `R^2^` for LaTeX which will use Math to render it. 

Usual conversion is: 
```
> pandoc -f markdown -t latex
R^2^
^Z
R\textsuperscript{2}
````

For other format, it is just using the native representation of this 
 ```
> pandoc -f markdown -t native
R^2^
^Z
[ Para [ Str "R" , Superscript [ Str "2" ] ] ]
```

which translates to each output correctly. Example for HTML
```
> pandoc -f markdown -t html
R^2^
^Z
<p>R<sup>2</sup></p>
```

## Usage

```markdown
Formatting R^2^ using Math for PDF: {{< r2 >}}
```

![image](https://user-images.githubusercontent.com/6791940/187522811-8b4abdef-3985-41a4-ab00-3676dbdbf772.png)


Idea from @topepo : Would that work for you ? 

Is this the place for this @dragonstyle  ? 