### PR TITLE
Add pct shortcode to write % as inline math in LaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Use shortcodes to get format specific fancy text for certain keywords or format 
 {{< ldots >}}
 {{< vdots >}}
 {{< ddots >}}
+{{< pct >}}
 ```
 
 For example:

--- a/_extensions/fancy-text/fancy-text.lua
+++ b/_extensions/fancy-text/fancy-text.lua
@@ -59,3 +59,12 @@ function ddots()
     return "..."
   end
 end
+
+function pct()
+  local pct
+  if quarto.doc.isFormat("pdf") then
+    return pandoc.Math('InlineMath', '\\%')
+  else 
+    return pandoc.Str("%")
+  end
+end

--- a/example.qmd
+++ b/example.qmd
@@ -14,3 +14,4 @@ TeX can be written like {{< tex >}}.
 
 Various elipses are supported: {{< ldots >}}, {{< vdots >}}, {{< ddots >}}
 
+% can be written in math in LaTeX with : {{< pct >}}, like 10{{< pct >}} 


### PR DESCRIPTION
This is another idea for @topepo

Usage would be 

````markdown
% can be written in math in LaTeX with : {{< pct >}}, like 10{{< pct >}} 
````

This would render in Tex as Inline Math 

![image](https://user-images.githubusercontent.com/6791940/187537289-0094c8ca-ef8b-4b8a-8e65-7f9b80043bca.png)

LaTeX produced is 

````latex
\% can be written in math in LaTeX with : \(\%\), like 10\(\%\)
````

I don't see much difference in resulting document @topepo by maybe in some scenario it is important ? 

In HTML and other format, it would stay as `%` as a string.

## Alternative 

Other usage of this could be 

````markdown
10% can be written in math in LaTeX with : {{< pct 10 >}} 
````

Possibly either using `$10\%$"` or `10$\%$`. 

Would that be a more useful syntax @topepo ? 